### PR TITLE
Move to labs.mapbox.com

### DIFF
--- a/.artifacts.yml
+++ b/.artifacts.yml
@@ -1,0 +1,3 @@
+version: v1
+defaults:
+  - publisher

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset='utf-8' />
     <title>Amnesty Oil Spills</title>
+    <link rel="canonical" href="https://labs.mapbox.com/amnesty/" >
     <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
     <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.42.2/mapbox-gl.js'></script>
     <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.42.2/mapbox-gl.css' rel='stylesheet' />


### PR DESCRIPTION
As discussed in https://github.com/mapbox/frontend-platform-team/issues/44, we are planning to move this repository the `labs` subdomain.
 
This PR adds:
- A canonical link to help search engines discern between duplicates and the original  `mapbox.com/amnesty`.
- Added `.artifacts.yml` and `_config.yml` to allow for publishing via Publisher.